### PR TITLE
Refactor duplicate profile fetch logic

### DIFF
--- a/CruiseControl/Social/CommentCell.swift
+++ b/CruiseControl/Social/CommentCell.swift
@@ -21,9 +21,7 @@ struct CommentCell: View {
 
       VStack(alignment: .leading) {
         HStack {
-          Text(
-            "\(firstName ?? "FirstNameLastName")\(lastName.map { $0 != "" ? " \($0)" : "" } ?? "")"
-          ).lineLimit(1).font(.caption2).bold().redacted(
+          Text(formattedDisplayName(firstName: firstName, lastName: lastName)).lineLimit(1).font(.caption2).bold().redacted(
             reason: !hasUserFetchBeenAttempted ? .placeholder : [])
           Text(postComment.createdAt.formatted()).font(.caption2).foregroundStyle(.secondary)
         }
@@ -37,26 +35,10 @@ struct CommentCell: View {
   }
 
   func fetchAuthorProfile() async {
-    guard let creator = postComment.creator else {
-      self.hasUserFetchBeenAttempted = true
-      return
-    }
-    let existingRecord = await potentiallyGetUserProfileRecord(userRecordID: creator)
-    if let existingRecord {
-      if let firstName = existingRecord.value(forKey: "firstName") as? String {
-        self.firstName = firstName
-      }
-      if let lastName = existingRecord.value(forKey: "lastName") as? String {
-        self.lastName = lastName
-      }
-
-      if let profilePicture = existingRecord.value(forKey: "profilePicture") as? CKAsset {
-        let fileURL = profilePicture.fileURL
-        if let fileURL {
-          self.profilePicture = fileURL
-        }
-      }
-    }
+    let info = await fetchUserProfileInfo(userRecordID: postComment.creator)
+    self.firstName = info.firstName
+    self.lastName = info.lastName
+    self.profilePicture = info.profilePicture
     self.hasUserFetchBeenAttempted = true
   }
 

--- a/CruiseControl/Social/SocialFeedPostAuthorView.swift
+++ b/CruiseControl/Social/SocialFeedPostAuthorView.swift
@@ -22,12 +22,9 @@ struct SocialFeedPostAuthorView: View {
       }
       VStack(alignment: .leading) {
         HStack {
-          Text(
-            "\(firstName ?? "FirstNameLastName")\(lastName.map { $0 != "" ? " \($0)" : "" } ?? "")"
-          )
-          .lineLimit(1)
-          .redacted(reason: !hasUserFetchBeenAttempted ? .placeholder : [])
-
+          Text(formattedDisplayName(firstName: firstName, lastName: lastName))
+            .lineLimit(1)
+            .redacted(reason: !hasUserFetchBeenAttempted ? .placeholder : [])
           Image(systemName: "checkmark.seal.fill")
             .foregroundColor(.yellow)
             .frame(width: 12)
@@ -45,26 +42,10 @@ struct SocialFeedPostAuthorView: View {
   }
 
   func fetchAuthorProfile() async {
-    guard let creator else {
-      self.hasUserFetchBeenAttempted = true
-      return
-    }
-    let existingRecord = await potentiallyGetUserProfileRecord(userRecordID: creator)
-    if let existingRecord {
-      if let firstName = existingRecord.value(forKey: "firstName") as? String {
-        self.firstName = firstName
-      }
-      if let lastName = existingRecord.value(forKey: "lastName") as? String {
-        self.lastName = lastName
-      }
-
-      if let profilePicture = existingRecord.value(forKey: "profilePicture") as? CKAsset {
-        let fileURL = profilePicture.fileURL
-        if let fileURL {
-          self.profilePicture = fileURL
-        }
-      }
-    }
+    let info = await fetchUserProfileInfo(userRecordID: creator)
+    self.firstName = info.firstName
+    self.lastName = info.lastName
+    self.profilePicture = info.profilePicture
     self.hasUserFetchBeenAttempted = true
   }
 

--- a/CruiseControl/Social/SocialUtils.swift
+++ b/CruiseControl/Social/SocialUtils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CloudKit
 
 func potentiallyRenderMarkdown(string: String) -> AttributedString {
   do {
@@ -9,4 +10,31 @@ func potentiallyRenderMarkdown(string: String) -> AttributedString {
   } catch {
     return AttributedString(stringLiteral: string)
   }
+}
+
+func formattedDisplayName(firstName: String?, lastName: String?) -> String {
+  let first = firstName ?? "FirstNameLastName"
+  guard let lastName, !lastName.isEmpty else {
+    return first
+  }
+  return "\(first) \(lastName)"
+}
+
+func fetchUserProfileInfo(userRecordID: CKRecord.ID?) async -> (
+  firstName: String?,
+  lastName: String?,
+  profilePicture: URL?
+) {
+  guard let userRecordID else { return (nil, nil, nil) }
+  guard let record = await potentiallyGetUserProfileRecord(userRecordID: userRecordID) else {
+    return (nil, nil, nil)
+  }
+  let firstName = record.value(forKey: "firstName") as? String
+  let lastName = record.value(forKey: "lastName") as? String
+  var pictureURL: URL? = nil
+  if let profilePicture = record.value(forKey: "profilePicture") as? CKAsset,
+     let url = profilePicture.fileURL {
+    pictureURL = url
+  }
+  return (firstName, lastName, pictureURL)
 }


### PR DESCRIPTION
## Summary
- centralize user profile formatting and fetch helpers
- use new helpers in comment and author views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683d7013714083309138841c613225c6